### PR TITLE
Add compression integration test

### DIFF
--- a/tests/integration/compression/Dockerfile
+++ b/tests/integration/compression/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN touch /dummyfile1
+RUN echo "hello" > /dummyfile2
+RUN dd if=/dev/zero of=/largefile bs=1M count=128

--- a/tests/integration/compression/test.sh
+++ b/tests/integration/compression/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Integration test: compression
+# This test aims to verify that the unpacker can handle compressed images
+
+set -o errexit -o nounset -o pipefail
+
+trap 'echo "Error on line $LINENO: $BASH_COMMAND"; exit 1' ERR
+
+docker pull alpine
+
+# MARK: Compressing the whole package
+for compression in gzip bzip2 xz; do
+  echo "Testing package compression with $compression"
+  __tmpdir=$(mktemp -d)
+  docker save alpine | $compression > "$__tmpdir/image.tar"
+  APP_LOG_LEVEL=INFO pdm run docker-unpack unpack "$__tmpdir/image.tar" "$__tmpdir/unpacked"
+  test -d "$__tmpdir/unpacked/etc"
+  rm -rf "$__tmpdir"
+done
+
+# MARK: Compressing the layers
+docker buildx create --name compression-test --driver docker-container --use
+
+for compression in gzip estargz; do
+  echo "Testing layer compression with $compression"
+
+    __tmpdir=$(mktemp -d)
+    docker buildx build --output type=docker,compression=$compression,force-compression=true,dest=- . > "$__tmpdir/image.tar"
+    test $(stat -c %s "$__tmpdir/image.tar") -lt $((10 * 1024 * 1024)) # check that the resulting image is sufficiently small
+
+    APP_LOG_LEVEL=INFO pdm run docker-unpack unpack "$__tmpdir/image.tar" "$__tmpdir/unpacked"
+    test -f "$__tmpdir/unpacked/largefile"
+    test $(stat -c %s "$__tmpdir/unpacked/largefile") -eq $((128 * 1024 * 1024)) # check that the unpacked file is the correct size
+    rm -rf "$__tmpdir"
+done
+
+docker buildx rm compression-test
+
+echo "PASS"

--- a/tests/integration/whiteout/test.sh
+++ b/tests/integration/whiteout/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Integration test: whiteout
+# This test aims to verify that whiteout files (deletions) are correctly handled by the unpacker
 
 set -o errexit -o nounset -o pipefail
 
@@ -20,5 +21,8 @@ test -d "$__tmpdir/dir/4"
 test ! -d "$__tmpdir/dir/5"
 test -d "$__tmpdir/dir/6"
 test -f "$__tmpdir/dir/6/somefile"
+
+rm -rf "$__tmpdir"
+docker rmi whiteout
 
 echo "PASS"


### PR DESCRIPTION
This PR adds compression integration tests. We don't test for zstd at the moment because it's not supported natively by the tarfile package in Python.