### PR TITLE
Relax Python requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Unpack Docker images for use with Apptainer and CVMFS"
 dependencies = [
     "watcloud-utils @ git+https://github.com/WATonomous/watcloud-utils.git@c8ce1006716e65971f750560f90f442721b3777d",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "BSD-2-Clause"}
 


### PR DESCRIPTION
This PR makes the Python requirement 3.10. All tests pass on 3.10.